### PR TITLE
Make `backendUrl` configurable via main config 

### DIFF
--- a/store/contantsDataNarrator.js
+++ b/store/contantsDataNarrator.js
@@ -39,7 +39,7 @@ const htmlEditorToolbar = [
     ["link", "image"]
 ];
 
-const backendUrl = process.env.BACKEND_URI || "https://staging-dana-backend.elie.de";
+const backendUrl = Config.backendUrl || "https://staging-dana-backend.elie.de";
 
 export {
     dataNarratorModes,


### PR DESCRIPTION
Since the `process.env` variables aren't available at runtime (easily), this makes use of config located in the portal's `config.js`.

Please review @ahennr.