### PR TITLE
Add missing protocol to links in rich text editor

### DIFF
--- a/features/stories/components/__new/step/StepDescription.vue
+++ b/features/stories/components/__new/step/StepDescription.vue
@@ -2,20 +2,21 @@
 import { useTranslation } from 'i18next-vue';
 import { computed } from 'vue';
 import { VueEditor } from 'vue3-editor';
+import { fixLinksInHTMLString } from '../../../../../utils/stringUtils';
 
 import * as constants from '../../../../../store/contantsDataNarrator';
 
 const props = defineProps({
-    value: String,
+  value: String,
 });
 const emit = defineEmits([ 'update:value' ]);
 const inputValue = computed({
-    get() {
-        return props.value
-    },
-    set(v) {
-        emit('update:value', v)
-    }
+  get() {
+    return props.value
+  },
+  set(v) {
+    emit('update:value', fixLinksInHTMLString(v))
+  }
 });
 
 const { t } = useTranslation();
@@ -33,26 +34,26 @@ const { t } = useTranslation();
 
 <style lang="scss">
 .editor-wrapper {
-    .quillWrapper {
-        display: flex;
-        flex-direction: column-reverse;
+  .quillWrapper {
+    display: flex;
+    flex-direction: column-reverse;
 
-        .ql-container {
-            border: 1px solid #ccc !important;
-            border-top-left-radius: 4px;
-            border-top-right-radius: 4px;
-            border-bottom: 0 !important;
-        }
-
-        .ql-container .ql-editor {
-            min-height: 80px;
-        }
-
-        .ql-toolbar {
-            border-top: 0;
-            border-bottom-left-radius: 4px;
-            border-bottom-right-radius: 4px;
-        }
+    .ql-container {
+      border: 1px solid #ccc !important;
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px;
+      border-bottom: 0 !important;
     }
+
+    .ql-container .ql-editor {
+      min-height: 80px;
+    }
+
+    .ql-toolbar {
+      border-top: 0;
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+    }
+  }
 }
 </style>

--- a/utils/stringUtils.js
+++ b/utils/stringUtils.js
@@ -1,3 +1,33 @@
 export function isNullOrWhitespace(str) {
-    return str === null || str === undefined || str.trim() === '';
+  return str === null || str === undefined || str.trim() === '';
+}
+
+/**
+ * Fix links in an HTML string to ensure they start with https:// or http://
+ *
+ * @param {string} htmlString
+ * @returns {string}
+ */
+export function fixLinksInHTMLString(htmlString) {
+  if (isNullOrWhitespace(htmlString)) {
+    return htmlString;
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(htmlString, 'text/html');
+  const elementsWithHref = doc.querySelectorAll('[href]');
+  elementsWithHref.forEach((el) => {
+    const href = el.getAttribute('href');
+    if (href && !href.startsWith('/') && !href.startsWith('http://') && !href.startsWith('https://')) {
+      el.setAttribute('href', `https://${href}`);
+    }
+  });
+  const elementsWithSrc = doc.querySelectorAll('[src]');
+  elementsWithSrc.forEach((el) => {
+    const src = el.getAttribute('src');
+    if (src && !src.startsWith('/') && !src.startsWith('http://') && !src.startsWith('https://')) {
+      el.setAttribute('src', `https://${src}`);
+    }
+  });
+  return doc.body.innerHTML;
 }


### PR DESCRIPTION
Ensure that links in the rich text editor are properly formatted to include the HTTP or HTTPS protocol. This change enhances link functionality and prevents potential navigation issues.

fixes #12