### PR TITLE
Minor adjustments to the confirm dialog of a new story

### DIFF
--- a/features/stories/components/inputs/ConfirmSavePopup.vue
+++ b/features/stories/components/inputs/ConfirmSavePopup.vue
@@ -1,12 +1,15 @@
 <script setup>
-import { mdiClose } from '@mdi/js';
-import { ref, computed } from 'vue';
+import { useTranslation } from 'i18next-vue';
 
 const props = defineProps({
-    dialogOpen: { type: Boolean, required: true },
-    okClicked: { type: Function, required: true },
-    cancelClicked: { type: Function, required: true },
+  dialogOpen: { type: Boolean, required: true },
+  okClicked: { type: Function, required: true },
+  cancelClicked: { type: Function, required: true },
 });
+
+const { t } = useTranslation();
+
+// TODO on close action of dialog, call cancelClicked
 </script>
 
 <template>
@@ -16,39 +19,40 @@ const props = defineProps({
   >
     <v-card>
       <v-card-title class="d-flex align-center">
-        Datenschutz
-        <v-spacer />
-        <v-btn
-          icon
-          variant="text"
-          @click="dialogOpen = false"
-        >
-          <v-icon :icon="mdiClose" />
-        </v-btn>
+        {{ t('additional:modules.dataNarrator.confirm.createStoryDataProtectionNotice.title') }}
       </v-card-title>
 
       <v-card-text>
-        Die Daten werden beim Anbieter gespeichert und verarbeitet. Mit dem Speichern stimmen Sie der
-        <a
-          href="https://cut.io/datenschutz/"
-          target="_blank"
-          rel="noopener"
-        >Datenschutzerklärung</a> zu.
+        <i18next
+          :translation="$t('additional:modules.dataNarrator.confirm.createStoryDataProtectionNotice.description')"
+        >
+          <template
+            #termsOfUseLink
+          >
+            <a
+              :href="$t('additional:modules.dataNarrator.confirm.createStoryDataProtectionNotice.termsOfUseLinkHref')"
+              target='_blank'
+              rel='noopener'
+            >
+              {{ $t('additional:modules.dataNarrator.confirm.createStoryDataProtectionNotice.termsOfUseLinkTitle') }}
+            </a>
+          </template>
+        </i18next>
       </v-card-text>
 
       <v-card-actions>
         <v-spacer />
         <v-btn
           variant="text"
-          @click="props.okClicked"
+          @click="props.cancelClicked"
         >
-          Ok
+          {{ t('additional:modules.dataNarrator.confirm.createStoryDataProtectionNotice.denyButton') }}
         </v-btn>
         <v-btn
           variant="text"
-          @click="props.cancelClicked"
+          @click="props.okClicked"
         >
-          Abbrechen
+          {{ t('additional:modules.dataNarrator.confirm.createStoryDataProtectionNotice.confirmButton') }}
         </v-btn>
       </v-card-actions>
     </v-card>

--- a/locales/de/additional.json
+++ b/locales/de/additional.json
@@ -136,7 +136,9 @@
         },
         "createStoryDataProtectionNotice": {
           "title": "Datenschutzerklärung Akzeptieren",
-          "description": "Indem Sie fortfahren, stimmen Sie unserer Datenschutzerklärung zu. Bitte lesen Sie diese sorgfältig, um zu verstehen, wie wir Ihre Daten verwenden und schützen.",
+          "description": "Indem Sie fortfahren, stimmen Sie unserer {termsOfUseLink} zu. Bitte lesen Sie diese sorgfältig, um zu verstehen, wie wir Ihre Daten verwenden und schützen.",
+          "termsOfUseLinkTitle": "Datenschutzerklärung",
+          "termsOfUseLinkHref": "https://cut.io/datenschutz/",
           "confirmButton": "Akzeptieren",
           "denyButton": "Nicht akzeptieren"
         },

--- a/locales/en/additional.json
+++ b/locales/en/additional.json
@@ -136,7 +136,9 @@
         },
         "createStoryDataProtectionNotice": {
           "title": "Accept Privacy Policy",
-          "description": "By continuing, you agree to our privacy policy. Please read it carefully to understand how we use and protect your data.",
+          "description": "By continuing, you agree to our {termsOfUseLink}. Please read it carefully to understand how we use and protect your data.",
+          "termsOfUseLinkTitle": "Privacy Policy",
+          "termsOfUseLinkHref": "https://cut.io/datenschutz/",
           "confirmButton": "Accept",
           "denyButton": "Do Not Accept"
         },


### PR DESCRIPTION
This fixes some minors in the confirm dialog while saving a new story:

- make contents translatable (and reuse existing locales)
- remove close icon (was without function)
- switch cancel and confirm button

Preview:

<img width="537" height="199" alt="image" src="https://github.com/user-attachments/assets/3c724f75-77c2-45e0-8f05-a5546d0bd1e2" />

Please review.