### PR TITLE
Use `dvh` unit for more accurate viewport height calculation in mobile ToolWindow

### DIFF
--- a/css/toolwindow.scss
+++ b/css/toolwindow.scss
@@ -81,7 +81,8 @@
 
         .toolwindow {
           background-color: rgb(246, 246, 246);
-          height: calc(100vh - 20px);
+          height: calc(100dvh - 20px);
+          @supports not (height: 100dvh) { height: calc(100vh - 20px); }
           overflow-y: auto;
           padding-top: 30px;
           scrollbar-width: none;


### PR DESCRIPTION
This PR updates the `.toolwindow` height calculation to use the `100dvh` (dynamic viewport height) unit instead of `100vh`. The `dvh` unit provides more accurate measurements on mobile browsers where the viewport height changes dynamically (e.g., when the address bar appears/disappears).

A fallback using `@supports` ensures compatibility with browsers that don't support `dvh`, maintaining the original `100vh` calculation for those cases.

Plz review 