### PR TITLE
Fetch stories immediately on mode change

### DIFF
--- a/features/dashboard/components/DashboardContent.vue
+++ b/features/dashboard/components/DashboardContent.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import { useStore } from 'vuex';
 
 import StoryCard from './Stories/StoryCard.vue';
@@ -13,6 +13,10 @@ const err = computed(() => store.state.Modules.DataNarrator.StoryStore.error);
 const fetchStories = () => {
   store.dispatch('Modules/DataNarrator/StoryStore/fetchStories', storiesDisplayMode.value);
 };
+
+watch(storiesDisplayMode, () => {
+  fetchStories();
+}, { immediate: true });
 
 </script>
 


### PR DESCRIPTION
Implement immediate fetching of stories when the display mode changes, enhancing the user experience by ensuring the latest stories are displayed without delay.

Fixes #70.