### PR TITLE
Override tooltip computed style

### DIFF
--- a/features/stories/components/step/StepDescription.vue
+++ b/features/stories/components/step/StepDescription.vue
@@ -52,6 +52,11 @@ const { t } = useTranslation();
       min-height: 80px;
     }
 
+    .ql-tooltip.ql-editing {
+      // override computed left style from thirdparty lib
+      left: 15px !important;
+    }
+
     .ql-toolbar {
       border-top: 0;
       border-bottom-left-radius: 4px;


### PR DESCRIPTION
Adjust the tooltip's computed left style to ensure proper positioning within the editor interface. This change enhances the user experience by improving the visibility and accessibility of the tooltip.

Fixes #72