### PR TITLE
Add admin check for featured button functionality

### DIFF
--- a/features/dashboard/components/Stories/FeaturedButton.vue
+++ b/features/dashboard/components/Stories/FeaturedButton.vue
@@ -18,18 +18,12 @@ const props = defineProps({
   isFeatured: {
     type: Boolean,
     required: true
-  },
-  isAdmin: {
-    type: Boolean,
-    default: false
   }
 });
 
 const featured = ref(props.isFeatured);
 
 async function makeItFeatured() {
-  if (!props.isAdmin) return;
-
   try {
     const res = await fetch(`${backendUrl}/stories/${props.storyId}/featured/${!featured.value}`, {
       method: 'POST'
@@ -54,7 +48,6 @@ async function makeItFeatured() {
         variant="text"
         density="compact"
         icon
-        :disabled="!isAdmin"
         @click.stop="makeItFeatured"
       >
         <v-icon
@@ -68,4 +61,3 @@ async function makeItFeatured() {
     </span>
   </v-tooltip>
 </template>
-

--- a/features/dashboard/components/Stories/StoryCard.vue
+++ b/features/dashboard/components/Stories/StoryCard.vue
@@ -22,7 +22,7 @@ const storiesDisplayMode = computed(() => {
   return store.state.Modules.DataNarrator.DashboardStore.mode
 });
 
-const { userId } = useLogin();
+const { userId, isAdmin } = useLogin();
 const { gotoPage } = useDataNarrator();
 const { currentStoryId } = useStory();
 const emit = defineEmits([ 'deleted', 'published' ]);
@@ -60,6 +60,7 @@ async function playStory() {
   const baseUrl = `${location.origin}/portal/stories/?id=${props.story.id}`;
   window.history.replaceState({}, '', baseUrl);
 }
+
 </script>
 
 <template>
@@ -85,11 +86,12 @@ async function playStory() {
         <ShareButton
           :story-id="story.id"
         />
-        <FeaturedButton
-          :story-id="story.id"
-          :is-featured="story.featured"
-          :is-admin="userId === story.owner"
-        />
+        <template v-if="isAdmin">
+          <FeaturedButton
+            :story-id="story.id"
+            :is-featured="story.featured"
+          />
+        </template>
         <PublishButton
           v-if="storiesDisplayMode === 'my' && userId === story.owner"
           :is-draft="story.isDraft"

--- a/features/dashboard/hooks/useLogin.js
+++ b/features/dashboard/hooks/useLogin.js
@@ -14,6 +14,14 @@ let tokenRenewalTimer = null;
 
 const logger = createLogger('useLogin');
 
+const ADMIN_ROLE = 'admin';
+
+function decodeJwt(token) {
+  const payload = token.split('.')[1];
+  const decoded = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')));
+  return decoded;
+}
+
 export function useLogin() {
   const { moveTool } = useDataNarrator();
 
@@ -25,6 +33,13 @@ export function useLogin() {
   const screenName = computed(() => store.state.Modules.Login.screenName);
   const username = computed(() => store.state.Modules.Login.username);
   const userId = computed(() => store.state.Modules.Login.userId);
+  const isAdmin = computed(() => {
+    const token = accessToken.value;
+    if (!token) return false;
+    const decoded = decodeJwt(token);
+    const roles = decoded?.realm_access?.roles;
+    return roles.includes(ADMIN_ROLE);
+  });
 
   const getAuthCodeUrl = async () => {
     return getRedirectUrl();
@@ -191,5 +206,6 @@ export function useLogin() {
     logout,
     checkLoggedIn,
     userId,
+    isAdmin
   }
 }


### PR DESCRIPTION
Implement an admin check for the featured button, ensuring only users with admin privileges can toggle the featured status of stories. Update the relevant components to reflect this change.

Relies on https://github.com/citysciencelab/cut-dana-platform-backend/pull/18

Fixes #8